### PR TITLE
feat: 친구 요청 전송

### DIFF
--- a/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
+++ b/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum FriendExceptionType implements ExceptionType {
 
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 친구가 없습니다."),
-    ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "이미 상대에게 친구 요청을 보냈습니다."),
+    ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "해당 친구와의 요청이 존재합니다."),
     ALREADY_FRIENDS(HttpStatus.BAD_REQUEST, "이미 상대와 친구 상태입니다.");
 
 

--- a/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
+++ b/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FriendExceptionType implements ExceptionType {
 
-    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 친구가 없습니다.");
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 친구가 없습니다."),
+    ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "이미 상대에게 친구 요청을 보냈습니다."),
+    ALREADY_FRIENDS(HttpStatus.BAD_REQUEST, "이미 상대와 친구 상태입니다.");
 
 
 

--- a/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
+++ b/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
@@ -1,16 +1,11 @@
 package com.highFour.LUMO.friend.api;
 
-import com.highFour.LUMO.friend.dto.FriendListRes;
 import com.highFour.LUMO.friend.service.FriendService;
-import com.highFour.LUMO.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping("/friends")
@@ -20,10 +15,19 @@ public class FriendController {
 
     private final FriendService friendService;
 
+    // TODO: 추후 RestAPI 고려해 수정 고려 (전체 메서드 체크)
+
     // 로그인한 회원 자신의 친구 목록 조회
     @GetMapping("/{memberId}")
     public ResponseEntity<?> getFriends(@PathVariable Long memberId){
         return new ResponseEntity<>(friendService.getFriendList(memberId), HttpStatus.OK);
+    }
+
+    // 회원가입한 회원 간 친구 맺기 요청 보내기
+    @PostMapping("/{senderId}/{receiverId}")
+    public ResponseEntity<?> sendFriendRequest(@PathVariable Long senderId, @PathVariable Long receiverId) {
+        friendService.sendFriendRequest(senderId, receiverId);
+        return new ResponseEntity<>("친구 요청이 정상적으로 전송되었습니다", HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/highFour/LUMO/friend/entity/FriendRequest.java
+++ b/src/main/java/com/highFour/LUMO/friend/entity/FriendRequest.java
@@ -1,0 +1,31 @@
+package com.highFour.LUMO.friend.entity;
+
+import com.highFour.LUMO.common.domain.BaseTimeEntity;
+import com.highFour.LUMO.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FriendRequest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FriendRequestStatus status;
+
+}

--- a/src/main/java/com/highFour/LUMO/friend/entity/FriendRequestStatus.java
+++ b/src/main/java/com/highFour/LUMO/friend/entity/FriendRequestStatus.java
@@ -1,0 +1,7 @@
+package com.highFour.LUMO.friend.entity;
+
+public enum FriendRequestStatus {
+    PENDING,   // 요청 대기 중
+    ACCEPTED,  // 요청 수락됨
+    REJECTED   // 요청 거절됨
+}

--- a/src/main/java/com/highFour/LUMO/friend/repository/FriendRepository.java
+++ b/src/main/java/com/highFour/LUMO/friend/repository/FriendRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findByMember1OrMember2(Member member1, Member member2);
+    boolean existsByMember1AndMember2(Member member1, Member member2);
 }

--- a/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
@@ -1,0 +1,10 @@
+package com.highFour.LUMO.friend.repository;
+
+import com.highFour.LUMO.friend.entity.Friend;
+import com.highFour.LUMO.friend.entity.FriendRequest;
+import com.highFour.LUMO.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    boolean existsBySenderAndReceiverOrReceiverAndSender(Member sender, Member receiver, Member receiver2, Member sender2);
+}

--- a/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
@@ -6,5 +6,5 @@ import com.highFour.LUMO.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    boolean existsBySenderAndReceiverOrReceiverAndSender(Member sender, Member receiver, Member receiver2, Member sender2);
+    boolean existsBySenderAndReceiver(Member sender, Member receiver);
 }

--- a/src/main/java/com/highFour/LUMO/friend/service/FriendService.java
+++ b/src/main/java/com/highFour/LUMO/friend/service/FriendService.java
@@ -46,14 +46,14 @@ public class FriendService {
 
     @Transactional
     public void sendFriendRequest(Long senderId, Long receiverId) {
-        // 회원 조회
         Member sender = memberRepository.findById(senderId)
                 .orElseThrow(() -> new EntityNotFoundException(MemberExceptionType.MEMBER_NOT_FOUND.message()));
 
         Member receiver = memberRepository.findById(receiverId)
                 .orElseThrow(() -> new EntityNotFoundException(MemberExceptionType.MEMBER_NOT_FOUND.message()));
 
-        boolean requestExists = friendRequestRepository.existsBySenderAndReceiverOrReceiverAndSender(sender, receiver, receiver, sender);
+        boolean requestExists = friendRequestRepository.existsBySenderAndReceiver(sender, receiver) ||
+                friendRequestRepository.existsBySenderAndReceiver(receiver, sender);
         if (requestExists) {
             throw new EntityNotFoundException(FriendExceptionType.ALREADY_REQUESTED.message());
         }

--- a/src/main/java/com/highFour/LUMO/member/config/SecurityConfig.java
+++ b/src/main/java/com/highFour/LUMO/member/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**").permitAll()
-                        .requestMatchers("/member/sign-up", "/member/sendAuthEmail", "/member/checkAuthNum").permitAll()
+                        .requestMatchers("/member/sign-up", "/member/sendAuthEmail", "/member/checkAuthNum", "/friends/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## 🔮 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 문서 작업

## #️⃣ 연관된 이슈
closed #20 

## 🔎 작업 내용
- 로그인한 회원이 회원가입한 회원에게 친구 요청 전송

## 📷 스크린샷
### **_친구 요청 전송_**
<img width="473" alt="스크린샷 2025-03-12 오후 10 36 47" src="https://github.com/user-attachments/assets/4fa51e32-1644-4b82-ace7-472c4de69f30" />

### **_동일 회원에게 친구 요청 재전송_**
<img width="544" alt="스크린샷 2025-03-12 오후 10 37 05" src="https://github.com/user-attachments/assets/faeb5df5-a82c-474e-b02e-a844fd39d9d3" />

### **_존재하지 않는 회원에게 친구 요청 전송_**
<img width="571" alt="스크린샷 2025-03-12 오후 10 38 23" src="https://github.com/user-attachments/assets/329cad5b-b5f8-429e-9699-fb820aabcb01" />


## ✔️ **‼️‼️기타사항‼️‼️**
- 현재 1번 회원이 2번 회원에게 전송하고 요청이 존재할 때, 2번 회원이 1번 회원에게 전송할 수 있습니다.
- 해당 사항에 대해 논의가 필요하다고 생각합니다.
- 1번이 보냈다면 2번이 또 못 보내게 할건지? 아니면 둘 다 보낼 수 있고 둘 중 한 명이 먼저 수락한다면 남아있는 요청은 지워질지?
- 근데 후자로 선택한다면 동시성 이슈 해결이 필요할 것 같네요. 전자가 나을 듯합니다 . .
- 전자로 결정된다면 코드 수정 후 머지하겠습니다 ~

## 해당 기타사항 반영 완료 !!