### PR TITLE
feat: 친구 요청 수락 / 거절 기능 구현

### DIFF
--- a/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
+++ b/src/main/java/com/highFour/LUMO/common/exceptionType/FriendExceptionType.java
@@ -8,7 +8,9 @@ public enum FriendExceptionType implements ExceptionType {
 
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 친구가 없습니다."),
     ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "해당 친구와의 요청이 존재합니다."),
-    ALREADY_FRIENDS(HttpStatus.BAD_REQUEST, "이미 상대와 친구 상태입니다.");
+    ALREADY_FRIENDS(HttpStatus.BAD_REQUEST, "이미 상대와 친구 상태입니다."),
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 친구 요청을 찾을 수 없습니다."),
+    INVALID_REQUEST_STATUS(HttpStatus.BAD_REQUEST,"유효하지 않은 친구 요청 상태입니다.");
 
 
 

--- a/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
+++ b/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
@@ -30,4 +30,18 @@ public class FriendController {
         return new ResponseEntity<>("친구 요청이 정상적으로 전송되었습니다", HttpStatus.OK);
     }
 
+    // 친구 요청 수락
+    @PostMapping("/accept/{senderId}/{receiverId}")
+    public ResponseEntity<String> acceptFriendRequest(@PathVariable Long senderId, @PathVariable Long receiverId) {
+        friendService.acceptFriendRequest(senderId, receiverId);
+        return new ResponseEntity<>("친구 요청을 수락하였습니다.", HttpStatus.OK);
+    }
+
+    // 친구 요청 거절
+    @PostMapping("/reject/{senderId}/{receiverId}")
+    public ResponseEntity<String> rejectFriendRequest(@PathVariable Long senderId, @PathVariable Long receiverId) {
+        friendService.rejectFriendRequest(senderId, receiverId);
+        return new ResponseEntity<>("친구 요청을 거절하였습니다.", HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/highFour/LUMO/friend/entity/FriendRequest.java
+++ b/src/main/java/com/highFour/LUMO/friend/entity/FriendRequest.java
@@ -28,4 +28,11 @@ public class FriendRequest extends BaseTimeEntity {
     @Column(nullable = false)
     private FriendRequestStatus status;
 
+    public void acceptRequest() {
+        this.status = status.ACCEPTED;
+    }
+
+    public void rejectRequest() {
+        this.status = status.REJECTED;
+    }
 }

--- a/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/highFour/LUMO/friend/repository/FriendRequestRepository.java
@@ -1,10 +1,12 @@
 package com.highFour.LUMO.friend.repository;
 
-import com.highFour.LUMO.friend.entity.Friend;
 import com.highFour.LUMO.friend.entity.FriendRequest;
 import com.highFour.LUMO.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     boolean existsBySenderAndReceiver(Member sender, Member receiver);
+    Optional<FriendRequest> findBySenderAndReceiver(Member sender, Member receiver);
 }


### PR DESCRIPTION
## 🔮 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 문서 작업

## #️⃣ 연관된 이슈
closed #24 

## 🔎 작업 내용
- 수락 시 친구 테이블에 추가 / 친구 요청 상태 ACCEPTED 변경
- 거절 시 친구 요청 상태 REJECTED 변경

## 📷 스크린샷
### 친구 요청 수락 시
**- 📍요청 전송 시 PENDING 상태**
<img width="144" alt="스크린샷 2025-03-17 오후 4 27 09" src="https://github.com/user-attachments/assets/4ed9b5a6-ce14-4968-ba2e-7bb2612ca37b" />
<br />

**-📍요청 수락처리**
<img width="612" alt="스크린샷 2025-03-17 오후 4 26 43" src="https://github.com/user-attachments/assets/3de71d42-0fc4-4ec6-90a0-d75eb66c6971" />

**- 📍수락 시 ACCEPTED 처리**
<img width="963" alt="스크린샷 2025-03-17 오후 4 27 20" src="https://github.com/user-attachments/assets/4cb43f90-738b-4618-b92d-6ce079f503d7" />

**- 📍친구 테이블에 친구 관계 회원으로 "친구" 객체 등록**
<img width="885" alt="스크린샷 2025-03-17 오후 4 27 29" src="https://github.com/user-attachments/assets/de20f58b-1f04-4d9a-84d8-3fe5ecbb9733" />

### 친구 요청 거절 시
**- 📍친구 요청 거절**
<img width="597" alt="스크린샷 2025-03-17 오후 4 29 50" src="https://github.com/user-attachments/assets/b32298ba-48d9-4029-878d-e8470b966520" />

**- 📍REJECTED 처리**
<img width="963" alt="스크린샷 2025-03-17 오후 4 29 58" src="https://github.com/user-attachments/assets/cf7095f8-f64b-4c81-b220-1c8462022fdf" />


## ✔️ 기타사항
### 📍이후 개발 계획
- 친구 끊기
  - 친구 끊어지면 이미 완료된 요청이 있더라도 요청을 또 보낼 수 있게 해야 함
  - 친구가 끊어지거나, 요청이 거절된다면
    - ACCEPTED, REJECTED 상태인 요청을 삭제 처리 => del_yn 구현 필요할 듯 ? DB 수정 ?!
    - 아니면 상태를 추가해서 끊어지면 요청의 상태를 다른 걸로 바꾸기 . . 뭐 그런 . .