### PR TITLE
feat: FCM 알림 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 
  ###yml ###
 .idea
+
+# fcm 알림
+lumo-e6475-firebase-adminsdk-fbsvc-4a50b93637.json

--- a/build.gradle
+++ b/build.gradle
@@ -38,17 +38,14 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
-
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+//	firebase 알림
+	implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 // 스프링 클라우드에 대한 버전 지정

--- a/src/main/java/com/highFour/LUMO/common/config/FcmConfig.java
+++ b/src/main/java/com/highFour/LUMO/common/config/FcmConfig.java
@@ -1,0 +1,40 @@
+package com.highFour.LUMO.common.config;
+import static com.highFour.LUMO.common.exceptionType.NotificationExceptionType.*;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.highFour.LUMO.common.exception.BaseCustomException;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.annotation.PostConstruct;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+	@Value("${fcm.secret-file}")
+	private String secretFileName;
+
+	@PostConstruct
+	public void initialize() {
+		try {
+			GoogleCredentials googleCredentials = GoogleCredentials
+				.fromStream(new ClassPathResource(secretFileName).getInputStream());
+			FirebaseOptions options = new FirebaseOptions.Builder()
+				.setCredentials(googleCredentials)
+				.build();
+			FirebaseApp.initializeApp(options);
+		} catch(FileNotFoundException e) {
+			throw new BaseCustomException(SECRET_FILE_NOT_FOUND);
+		} catch(IOException e) {
+			throw new BaseCustomException(INVALID_SECRET_FILE);
+		}
+
+	}
+}

--- a/src/main/java/com/highFour/LUMO/common/exceptionType/NotificationExceptionType.java
+++ b/src/main/java/com/highFour/LUMO/common/exceptionType/NotificationExceptionType.java
@@ -1,0 +1,26 @@
+package com.highFour.LUMO.common.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum NotificationExceptionType implements ExceptionType{
+	SECRET_FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 시크릿 파일이 없습니다."),
+	INVALID_SECRET_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 형식의 FCM 시크릿 파일입니다."),
+	FCM_TOKEN_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "유저의 FCM 토큰이 존재하지 않습니다."),
+	FCM_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송에 실패했습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus httpStatus() {
+		return status;
+	}
+
+	@Override
+	public String message() {
+		return message;
+	}
+}

--- a/src/main/java/com/highFour/LUMO/diary/service/DiaryService.java
+++ b/src/main/java/com/highFour/LUMO/diary/service/DiaryService.java
@@ -34,8 +34,6 @@ import com.highFour.LUMO.diary.repository.EmotionRepository;
 import com.highFour.LUMO.diary.repository.HashtagRepository;
 import com.highFour.LUMO.member.repository.MemberRepository;
 
-import jakarta.persistence.EntityNotFoundException;
-
 @Service
 public class DiaryService {
 	private final EmotionRepository emotionRepository;

--- a/src/main/java/com/highFour/LUMO/member/entity/Member.java
+++ b/src/main/java/com/highFour/LUMO/member/entity/Member.java
@@ -48,6 +48,8 @@ public class Member extends BaseTimeEntity {
 
     private String refreshToken;
 
+    private String fcmToken;
+
     @Builder.Default
     private boolean deleted = false;
 
@@ -55,6 +57,9 @@ public class Member extends BaseTimeEntity {
         this.role = Role.MEMBER;
     }
 
+    public void updateFcmToken(String fcmToken){
+        this.fcmToken = fcmToken;
+    }
 
     // 비밀번호 암호화 메소드
     public void passwordEncode(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/highFour/LUMO/notification/api/FcmController.java
+++ b/src/main/java/com/highFour/LUMO/notification/api/FcmController.java
@@ -1,0 +1,34 @@
+package com.highFour.LUMO.notification.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.highFour.LUMO.notification.dto.FcmTokenSaveRequest;
+import com.highFour.LUMO.notification.service.FcmService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/fcm")
+@RestController
+public class FcmController {
+	private final FcmService fcmService;
+
+	// fcm 토큰 저장
+	@PostMapping("/token")
+	public ResponseEntity<Void> saveFcmToken(@RequestBody FcmTokenSaveRequest fcmTokenSaveRequest) {
+		fcmService.saveFcmToken(fcmTokenSaveRequest);
+		return ResponseEntity.ok(null);
+	}
+
+	// 테스트용 알림 전송
+	@PostMapping("/notice")
+	public ResponseEntity<Void> sendNotification() {
+		fcmService.sendNotification();
+		return ResponseEntity.ok(null);
+	}
+}

--- a/src/main/java/com/highFour/LUMO/notification/dto/FcmTokenSaveRequest.java
+++ b/src/main/java/com/highFour/LUMO/notification/dto/FcmTokenSaveRequest.java
@@ -1,0 +1,4 @@
+package com.highFour.LUMO.notification.dto;
+
+public record FcmTokenSaveRequest(String fcmToken) {
+}

--- a/src/main/java/com/highFour/LUMO/notification/service/FcmService.java
+++ b/src/main/java/com/highFour/LUMO/notification/service/FcmService.java
@@ -1,0 +1,67 @@
+package com.highFour.LUMO.notification.service;
+
+import static com.highFour.LUMO.common.exceptionType.MemberExceptionType.*;
+import static com.highFour.LUMO.common.exceptionType.NotificationExceptionType.*;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
+import com.highFour.LUMO.common.exception.BaseCustomException;
+import com.highFour.LUMO.common.exceptionType.MemberExceptionType;
+import com.highFour.LUMO.member.entity.Member;
+import com.highFour.LUMO.member.repository.MemberRepository;
+import com.highFour.LUMO.notification.dto.FcmTokenSaveRequest;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FcmService {
+	private final MemberRepository memberRepository;
+
+	// fcm 토큰 저장
+	@Transactional
+	public void saveFcmToken(FcmTokenSaveRequest fcmTokenSaveRequest) {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new BaseCustomException(MEMBER_NOT_FOUND));
+
+		member.updateFcmToken(fcmTokenSaveRequest.fcmToken());
+	}
+
+	// 알림 전송
+	public void sendNotification() {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new BaseCustomException(MEMBER_NOT_FOUND));
+
+		String token = member.getFcmToken();
+		if(token == null || token.isEmpty()) {
+			throw new BaseCustomException(FCM_TOKEN_NOT_FOUND);
+		}
+
+		Message message = Message.builder()
+			.setWebpushConfig(WebpushConfig.builder()
+				.setNotification(WebpushNotification.builder()
+					.setTitle("테스트 알림 제목")
+					.setBody("테스트 알림 내용")
+					.build())
+				.build())
+			.setToken(token)
+			.build();
+
+		try {
+			FirebaseMessaging.getInstance().sendAsync(message);
+		} catch(Exception e) {
+			throw new BaseCustomException(FCM_SEND_FAIL);
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,12 @@ cloud:
     s3:
       bucket: lumo-file
 
-
 logging:
   level:
     root: info
+
+fcm:
+  secret-file: ${FCM_SECRET_FILE}
+  key:
+    path: filePath*.json
+    scope: https://www.googleapis.com/auth/firebase.messageing


### PR DESCRIPTION
## 🔮 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 문서 작업

## #️⃣ 연관된 이슈
closed #23 

## 🔎 작업 내용
- fcm config 
- fcm token을 member 테이블에 저장
- 테스트 알림 메시지 전송

## 📷 스크린샷
### 💭 fcm token 저장
**프론트에서 발급받은 토큰을 member 테이블에 저장**

![스크린샷 2025-03-18 오후 10 58 25](https://github.com/user-attachments/assets/b7819de0-7719-4fa4-9ef5-ebc070647ac5)

![스크린샷 2025-03-18 오후 11 00 48](https://github.com/user-attachments/assets/6d408e92-447b-4560-8412-760305d26d50)

###  💭 테스트 알림 메시지 전송
![스크린샷 2025-03-18 오후 11 11 07](https://github.com/user-attachments/assets/f0441f75-ff2e-4fe0-8d1a-286af2bdf59d)

![스크린샷 2025-03-18 오후 11 11 44](https://github.com/user-attachments/assets/cac7e855-4134-4800-9b36-4ce63ba115d0)


## ✔️ 기타사항
💭 이후 개발 계획
기본적인 알림 틀을 구현해둬서 백엔드는 마지막에 알림 붙이면 될 듯 싶어요..
프론트로 가겠습니다..야금야금 조금씩 조금씩 고쳐나갈게요..

‼️환경변수랑 yml 이랑 json파일 수정했으니 반영하셔요‼️
‼️json은 resources 폴더 안에‼️