### PR TITLE
feat: 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/highFour/LUMO/comment/api/CommentController.java
+++ b/src/main/java/com/highFour/LUMO/comment/api/CommentController.java
@@ -18,17 +18,22 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<CommentRes> createComment(@RequestBody CommentReq commentReq) {
+    public ResponseEntity<?> createComment(@RequestBody CommentReq commentReq) {
         CommentRes commentRes = commentService.createComment(commentReq);
         return new ResponseEntity<>(commentRes, HttpStatus.OK);
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<CommentRes> updateComment(@PathVariable Long commentId, @RequestBody Map<String, String> requestBody) {
+    public ResponseEntity<?> updateComment(@PathVariable Long commentId, @RequestBody Map<String, String> requestBody) {
         String newContent = requestBody.get("content");
         CommentRes updatedComment = commentService.updateComment(commentId, newContent);
         return new ResponseEntity<>(updatedComment, HttpStatus.OK);
     }
 
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return new ResponseEntity<>("댓글이 삭제되었습니다.", HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/highFour/LUMO/comment/entity/Comment.java
+++ b/src/main/java/com/highFour/LUMO/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.highFour.LUMO.comment.entity;
 
 import com.highFour.LUMO.common.domain.BaseTimeEntity;
 import com.highFour.LUMO.diary.entity.Diary;
+import com.highFour.LUMO.member.entity.DelYn;
 import com.highFour.LUMO.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,6 +35,18 @@ public class Comment extends BaseTimeEntity {
 
     public void updateContent(String newContent) {
         this.content = newContent;
+    }
+
+    @Enumerated(EnumType.STRING)
+    @JoinColumn(name = "del_yn", nullable = false)
+    private DelYn delYn = DelYn.N;
+
+    public void updateDeleted() {
+        this.delYn = DelYn.Y;
+    }
+
+    public boolean isDeleted() {
+        return this.delYn == DelYn.Y;
     }
 
 }

--- a/src/main/java/com/highFour/LUMO/common/exceptionType/CommentExceptionType.java
+++ b/src/main/java/com/highFour/LUMO/common/exceptionType/CommentExceptionType.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 public enum CommentExceptionType implements ExceptionType {
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-    UNAUTHORIZED_COMMENT_EDIT(HttpStatus.UNAUTHORIZED, "댓글 작성자만 수정할 수 있습니다.");
+    PARENT_COMMENT_DELETED(HttpStatus.NOT_FOUND, "삭제된 댓글에 답글을 작성할 수 없습니다."),
+    UNAUTHORIZED_COMMENT_EDIT(HttpStatus.UNAUTHORIZED, "댓글 작성자만 수정할 수 있습니다."),
+    UNAUTHORIZED_COMMENT_DELETE(HttpStatus.UNAUTHORIZED, "댓글 작성자만 삭제할 수 있습니다.");
 
 
 

--- a/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
+++ b/src/main/java/com/highFour/LUMO/friend/api/FriendController.java
@@ -24,27 +24,27 @@ public class FriendController {
 
     // 회원가입한 회원 간 친구 맺기 요청 보내기
     @PostMapping("/request")
-    public ResponseEntity<String> sendFriendRequest(@RequestBody FriendRequestReq requestDto) {
+    public ResponseEntity<?> sendFriendRequest(@RequestBody FriendRequestReq requestDto) {
         friendService.sendFriendRequest(requestDto);
-        return ResponseEntity.ok("친구 요청이 전송되었습니다.");
+        return new ResponseEntity<>("친구 요청이 전송되었습니다.", HttpStatus.OK);
     }
 
     // 친구 요청 수락
     @PostMapping("/accept/{receiverId}")
-    public ResponseEntity<String> acceptFriendRequest(@PathVariable Long receiverId) {
+    public ResponseEntity<?> acceptFriendRequest(@PathVariable Long receiverId) {
         friendService.acceptFriendRequest(receiverId);
         return new ResponseEntity<>("친구 요청을 수락하였습니다.", HttpStatus.OK);
     }
 
     // 친구 요청 거절
     @PostMapping("/reject/{receiverId}")
-    public ResponseEntity<String> rejectFriendRequest(@PathVariable Long receiverId) {
+    public ResponseEntity<?> rejectFriendRequest(@PathVariable Long receiverId) {
         friendService.rejectFriendRequest(receiverId);
         return new ResponseEntity<>("친구 요청을 거절하였습니다.", HttpStatus.OK);
     }
 
     @DeleteMapping("/unfriend/{friendId}")
-    public ResponseEntity<String> unfriend(@PathVariable Long friendId) {
+    public ResponseEntity<?> unfriend(@PathVariable Long friendId) {
         friendService.unfriend(friendId);
         return new ResponseEntity<>("친구가 삭제 되었습니다.", HttpStatus.OK);
     }


### PR DESCRIPTION
## 🔮 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 문서 작업

## #️⃣ 연관된 이슈
closed #45 

## 🔎 작업 내용
- 작성한 댓글 삭제
- 삭제된 댓글에 답글을 달 수 없도록 처리

## 📷 스크린샷
<img width="338" alt="스크린샷 2025-03-24 오후 3 53 58" src="https://github.com/user-attachments/assets/09c36161-51e0-4a86-98fc-7d311dde7606" />

### 📍 내용을 null 처리 해버리면 댓글 작성시에도 null 로 댓글이 달아지기 때문에 delYn 만 처리하였습니다.
### 이후 프론트에서 delYn 인데 답글이 없으면 안 보여주기 / 답글이 있으면 "삭제된 댓글입니다." 로 보여주기 처리 예정
<img width="820" alt="스크린샷 2025-03-24 오후 3 54 36" src="https://github.com/user-attachments/assets/0db9d8c2-e231-4443-a4be-c1907f0a473a" />

<img width="522" alt="스크린샷 2025-03-24 오후 3 54 59" src="https://github.com/user-attachments/assets/8cd9ba44-d1ec-4c3d-9088-49b0a0144d54" />


## ✔️ 기타사항
Friend 코드 및 Comment 코드의 Controller 코드를 통일하였습니다. (수정)